### PR TITLE
Add JPARepository and Query Methods

### DIFF
--- a/src/main/java/com/proyectospring/proyectomarket/persistencia/ProductRepository.java
+++ b/src/main/java/com/proyectospring/proyectomarket/persistencia/ProductRepository.java
@@ -1,0 +1,49 @@
+package com.proyectospring.proyectomarket.persistencia;
+
+import com.proyectospring.proyectomarket.persistencia.crud.ProductCrudRepository;
+import com.proyectospring.proyectomarket.persistencia.entity.Producto;
+
+import java.util.List;
+import java.util.Optional;
+
+public class ProductRepository {
+    private ProductCrudRepository productCrudRepository;
+
+    public List<Producto> getAll (){
+       return  (List<Producto>) productCrudRepository.findAll();
+    }
+
+    public List<Producto> getByCategoria(int idCategoria){
+        return productCrudRepository.findByidCategoriaOderByNombreAsc(idCategoria);
+    }
+
+    public Optional<List<Producto>> getEscasos(int cantidad){
+        return productCrudRepository.findByCantidadStockLessThanAndEstado(cantidad, true);
+    }
+
+    public Optional<Producto> getById(int idProducto){
+        return  productCrudRepository.findById(idProducto);
+    }
+
+    public void deleteProduct(int idProducto){
+        productCrudRepository.deleteById(idProducto);
+    }
+
+    public Producto save(Producto producto){
+        return  productCrudRepository.save(producto);
+    }
+    public Producto updateProduct(int idProducto, Producto producto){
+        Producto productoExistente = productCrudRepository.findById(idProducto)
+                .orElseThrow(()-> new IllegalArgumentException("Producto no encontrado"));
+
+        //actualizar los campos
+        productoExistente.setNombre(producto.getNombre());
+        productoExistente.setCantidadSto(producto.getCantidadSto());
+        productoExistente.setCodigoBarra(producto.getCodigoBarra());
+        productoExistente.setPrecioVenta(producto.getPrecioVenta());
+        productoExistente.setEstado(producto.getEstado());
+
+        return productCrudRepository.save(productoExistente);
+    }
+
+}

--- a/src/main/java/com/proyectospring/proyectomarket/persistencia/crud/ProductCrudRepository.java
+++ b/src/main/java/com/proyectospring/proyectomarket/persistencia/crud/ProductCrudRepository.java
@@ -1,0 +1,15 @@
+package com.proyectospring.proyectomarket.persistencia.crud;
+
+import com.proyectospring.proyectomarket.persistencia.entity.Producto;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ProductCrudRepository extends CrudRepository<Producto,Integer> {
+
+    List<Producto> findByidCategoriaOderByNombreAsc(int idCategoria);
+    Optional<List<Producto>> findByCantidadStockLessThanAndEstado(int cantidadStock, boolean estado);
+
+
+}

--- a/src/main/java/com/proyectospring/proyectomarket/persistencia/entity/Producto.java
+++ b/src/main/java/com/proyectospring/proyectomarket/persistencia/entity/Producto.java
@@ -30,7 +30,7 @@ public class Producto {
         return idProducto;
     }
     @Column(name = "cantidad_sto")
-    private Integer cantidadSto;
+    private Integer cantidadStock;
 
     private boolean estado;
 
@@ -66,14 +66,14 @@ public class Producto {
     }
 
     public Integer getCantidadSto() {
-        return cantidadSto;
+        return cantidadStock;
     }
 
     public void setCantidadSto(Integer cantidadSto) {
-        this.cantidadSto = cantidadSto;
+        this.cantidadStock = cantidadSto;
     }
 
-    public boolean isEstado() {
+    public boolean getEstado() {
         return estado;
     }
 


### PR DESCRIPTION
### Add JPARepository and Query Methods.

Implementación 

> Paso 1:  Se crea una interface que extienda de CrudRepository.
> Paso 2: Se crea un archivo de tipo class que va contener todos los métodos de producto [ej: getProduct(){}]
> Paso 3: Se añade una propiedad al archivo de nombre productCrudReposity de tipo ProductCrudReposity.

A partir de aquí se podrán utilizar los métodos que ofrece el repositorio JPA. 